### PR TITLE
feat: implement image lazy loading with intersection observer

### DIFF
--- a/components/gallery/gallery.tsx
+++ b/components/gallery/gallery.tsx
@@ -8,19 +8,20 @@ interface Props {
   photos: Photo[];
 }
 
-const Gallery = ({ className, photos }: Props): JSX.Element => (
-  <Container>
-    {photos.map(({ height, orientation, publicId, version, width }: Photo) =>
-      <Picture
-        height={height}
-        key={`${publicId}-${version}`}
-        orientation={orientation}
-        publicId={publicId}
-        version={version}
-        width={width}
-      />
-    )}
-  </Container>
-);
+const Gallery = ({ className, photos }: Props): JSX.Element => {
+  return (
+    <Container className={className}>
+      {photos.map(({ orientation, publicId, version }: Photo) =>
+        <Picture
+          key={`${publicId}-${version}`}
+          lazyLoad
+          orientation={orientation}
+          publicId={publicId}
+          version={version}
+        />
+      )}
+    </Container>
+  );
+};
 
 export default Gallery;

--- a/components/loading/loading.css.tsx
+++ b/components/loading/loading.css.tsx
@@ -1,0 +1,47 @@
+import styled, { css, keyframes, Keyframes } from 'styled-components';
+import { animationCurve, colours } from '../../styles';
+
+export enum Direction {
+  UP = 'UP',
+  DOWN = 'DOWN',
+}
+
+interface SquareProps {
+  direction: Direction
+}
+
+const verticalBounce = (direction: Direction): Keyframes => keyframes`
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  25% {
+    transform: translate3d(0, ${direction === Direction.UP ? '0.5rem' : '-0.5rem'}, 0);
+  }
+  75% {
+    transform: translate3d(0, ${direction === Direction.DOWN ? '0.5rem' : '-0.5rem'}, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+`;
+
+export const Container = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+`;
+
+export const Square = styled.div<SquareProps>`
+  width: 1rem;
+  height: 0.5rem;
+  background: ${colours.primary};
+
+  ${({ direction }: SquareProps) => css`
+    animation: ${verticalBounce(direction)} 1000ms linear infinite;
+  `}
+`;

--- a/components/loading/loading.tsx
+++ b/components/loading/loading.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import { colours } from '../../styles';
+import { Container, Direction, Square } from './loading.css';
+
+interface Props {
+  className?: string;
+  strips?: number;
+}
+
+const Loading = ({ className, strips = 15 }: Props): JSX.Element => (
+  <Container className={className}>
+    <Square direction={Direction.UP} />
+    <Square direction={Direction.DOWN} />
+    <Square direction={Direction.UP} />
+    <Square direction={Direction.DOWN} />
+    <Square direction={Direction.UP} />
+    <Square direction={Direction.DOWN} />
+  </Container>
+);
+
+export default Loading;

--- a/components/navigation/navigation.tsx
+++ b/components/navigation/navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import config from '../../config';
+import { albums } from '../../config';
 import { Nav, NavItemList } from './navigation.css';
 
 interface Props {
@@ -12,10 +12,8 @@ const capitalise = (item: string): string =>
   `${item.charAt(0).toUpperCase()}${item.slice(1)}`
 ;
 
-const AlbumLinks = (onClick): JSX.Element[] => {
-  const { albums } = config;
-
-  return albums.map((slug: string): JSX.Element => (
+const AlbumLinks = (onClick): JSX.Element[] => (
+  albums.map((slug: string): JSX.Element => (
     <li key={slug}>
       <Link
         as={`/albums/${slug}`}
@@ -24,8 +22,8 @@ const AlbumLinks = (onClick): JSX.Element[] => {
         <a onClick={onClick}>{capitalise(slug)}</a>
       </Link>
     </li>
-  ));
-}
+  ))
+);
 
 const Navigation = ({
   className,

--- a/components/picture/picture.css.tsx
+++ b/components/picture/picture.css.tsx
@@ -1,19 +1,25 @@
 import styled, { css } from 'styled-components';
-import { media } from '../../styles/mixins';
 import { Orientation } from '../../types';
+import { animationCurve, colours } from '../../styles';
+import Loading from '../loading/loading';
 
 interface ImageProps {
-  calcHeight: number;
-  calcWidth: number;
-  orientation: Orientation;
+  hasLoaded: boolean;
 }
 
 interface PictureProps {
+  hasLoaded: boolean;
   orientation: Orientation;
 }
 
 export const PictureContainer = styled.picture<PictureProps>`
   position: relative;
+  border: 1px solid ${colours.tertiary};
+  transition: border 350ms ${animationCurve};
+
+  ${({ hasLoaded }) => hasLoaded && css`
+    border: 1px solid ${colours.secondary};
+  `}
 
   ${({ orientation }: PictureProps) => orientation === Orientation.Portrait && css`
     grid-row-end: span 2;
@@ -25,4 +31,17 @@ export const Image = styled.img<ImageProps>`
   height: 100%;
   object-position: center;
   object-fit: cover;
+  opacity: 0;
+  transition: opacity 350ms ${animationCurve};
+
+  ${({ hasLoaded }) => hasLoaded && css`
+    opacity: 1.0;
+  `};
 `;
+
+export const LoadingStrip = styled(Loading)`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+`

--- a/config.ts
+++ b/config.ts
@@ -1,28 +1,44 @@
-export interface CloudinaryApi {
-  cloudName: string,
-  key: string;
-  maxResults: string,
-  secret: string;
-  apiUrl: string;
-}
+import { PictureSourceSize } from './interfaces';
 
-const albums: string[] = [
+export const albums: string[] = [
   'abandoned', 'people', 'music',
   'experimental', 'city', 'landscapes',
   'events', 'nature',
 ];
 
-const cloudinary: CloudinaryApi = {
-  cloudName: process.env.CLOUD_NAME,
-  key: process.env.KEY,
-  maxResults: process.env.MAX_RESULTS,
-  secret: process.env.SECRET,
-  apiUrl: process.env.API_URL,
-};
+export const sourceMediaQueries: PictureSourceSize[] = [
+  {
+    minWidth: 1920,
+    sizes: [960, 1920, 2560]
+  },
+  {
+    minWidth: 1440,
+    sizes: [1024, 2048, 2560]
+  },
+  {
+    minWidth: 1280,
+    sizes: [680, 1360, 2040]
+  },
+  {
+    minWidth: 1024,
+    sizes: [576, 1152, 1728]
+  },
+  {
+    minWidth: 768,
+    sizes: [448, 896, 1344]
+  },
+  {
+    minWidth: 640,
+    sizes: [724, 1448, 2172]
+  },
+  {
+    minWidth: 480,
+    sizes: [560, 1120, 1680]
+  },
+  {
+    minWidth: 320,
+    sizes: [320, 640, 960]
+  },
+];
 
-const config = {
-  albums,
-  cloudinary,
-};
-
-export default config;
+export const resourceBaseUrl = 'https://res.cloudinary.com/matt-finucane-portfolio/image/upload';

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+const useIntersectionObserver = (ref: React.MutableRefObject<any>, cb: () => void): void => {
+  useEffect((): () => void => {
+    if(!('IntersectionObserver' in window)) {
+      cb();
+      return;
+    }
+
+    const { current } = ref;
+    const observer = new IntersectionObserver((
+      [{ intersectionRatio }]: IntersectionObserverEntry[]
+    ): void => {
+      if(intersectionRatio > 0) {
+        observer.unobserve(current);
+        cb();
+      }
+    });
+
+    observer.observe(current);
+
+    return (): void => {
+      observer.unobserve(current);
+    };
+  }, [ref]);
+};
+
+export default useIntersectionObserver;

--- a/lib/albums.ts
+++ b/lib/albums.ts
@@ -1,11 +1,9 @@
 import { promises as fs } from 'fs';
-import config from '../config';
+import { albums } from '../config';
 import { Param, Photo } from '../interfaces';
 import { Orientation } from '../types';
 
 export const getAlbumIds = (): Param[] => {
-  const { albums } = config;
-
   return albums.map((id: string): Param => (
     {
       params: {

--- a/styles/vars.ts
+++ b/styles/vars.ts
@@ -13,6 +13,7 @@ export const breakpoints: Breakpoints = {
 export const colours: Colours = {
   primary: '#000',
   secondary: '#fff',
+  tertiary: '#ccc',
 };
 
 export const layers: Layers = {

--- a/types.ts
+++ b/types.ts
@@ -9,6 +9,7 @@ export type Breakpoints = {
 export type Colours = {
   primary: string;
   secondary: string;
+  tertiary: string;
 }
 
 export type Layers = {


### PR DESCRIPTION
#### What is this?
This PR implements lazy loading for images using the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). Here is how it works.

- A new hook (`useIntersectionObserver`) has been created and is used in the `Picture` component. If the image intersection ratio is > 0, as in, if any part of it is in the viewport, it is loaded.
- We do this by attaching the generated srcSet to the `<source />` tags within the picture element.
- The image sizes have also been tweaked so that the most appropriately sized image is delivered so as to create the right balance of bandwidth usage and image quality. The screen DPI, viewport size and grid set up all factor in to this.
- a loading component has been created, which itself kicks in when the picture (not yet loaded) is scrolled into view.