### PR TITLE
fix: correct deployment setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,13 @@ jobs:
           command: yarn lint
 
   build:
-    machine: true
+    docker:
+      - image: node:12.18-alpine
     steps:
       - checkout
+      - run:
+          name: Install yarn dependencies
+          command: yarn
       - run:
           name: NextJS static export
           command: yarn export
@@ -49,7 +53,7 @@ jobs:
             - "69:f4:84:f0:e9:82:8a:88:4e:f2:94:a2:25:80:f1:cb"
       - run:
           name: Copy docker compose files to remote server
-          command: scp -r docker-compose.yml docker-compose.prod.yml .docker/ $DEPLOY_USER@$DEPLOY_HOST:~/
+          command: scp -r docker-compose.yml docker-compose.prod.yml .docker/ out/ $DEPLOY_USER@$DEPLOY_HOST:~/
       - run:
           name: Remotely pull docker images, then restart the container
           command: |

--- a/.docker/nginx/Dockerfile
+++ b/.docker/nginx/Dockerfile
@@ -1,4 +1,5 @@
 FROM      nginx:alpine
 RUN       mkdir -p /opt/public
 RUN       rm /etc/nginx/conf.d/default.conf
-COPY      templates/nginx.conf.template /etc/nginx/templates/nginx.conf.template
+COPY      out/ /opt/public
+COPY      .docker/nginx/templates/nginx.conf.template /etc/nginx/templates/nginx.conf.template

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 
 # Exceptions
 !/out/**
+!/.docker/**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     container_name: cinematt
     image: matfin/cinematt:latest
     build:
-      context: .docker/nginx/
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: .docker/nginx/Dockerfile
     environment:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
       - NGINX_HOST=cinematt.build
@@ -16,6 +16,5 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./out:/opt/public:ro
       - ~/ssl/letsencrypt:/etc/letsencrypt:ro
     command: nginx -g "daemon off;"


### PR DESCRIPTION
#### What is this?
This PR corrects deployment issues as follows:
- the `out/` directory is copied into the container via the Dockerfile
- the volumes entry in Docker compose is no longer applicable for this
- the build workflow inside the CircleCi config has been corrected to include the correct docker node image and yarn dependency install instructions with no caching.