### PR TITLE
fix: add nex build command to build state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
           name: Install yarn dependencies
           command: yarn
       - run:
+          name: NextJS build
+          command: yarn build
+      - run:
           name: NextJS static export
           command: yarn export
       - run:


### PR DESCRIPTION
#### What is this?
This is a hot fix to correct a build issue with NextJS. The `yarn build` command must be run before `yarn export` or the latter will fail. I have added `yarn build` as an extra step to correct the issue.