### PR TITLE
refactor: simplify docker and circleci config build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ jobs:
     docker:
       - image: node:12.18-alpine
     steps:
+      - run:
+          name: Install Git
+          command: apk add --update git
       - checkout
       - restore_cache:
           name: Restore build cache
@@ -25,33 +28,6 @@ jobs:
       - run:
           name: Run code lint
           command: yarn lint
-
-  build-copy-files:
-    docker:
-      - image: node:12.18-alpine
-    steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "69:f4:84:f0:e9:82:8a:88:4e:f2:94:a2:25:80:f1:cb"
-      - run:
-          name: Install SCP to copy files
-          command: apk add --update openssh
-      - run:
-          name: Add key to known_hosts
-          command: mkdir -p ~/ssh && ssh-keyscan $DEPLOY_HOST >> ~/.ssh/known_hosts
-      - run:
-          name: Install yarn dependencies
-          command: yarn
-      - run:
-          name: NextJS build
-          command: yarn build
-      - run:
-          name: NextJS export of static content
-          command: yarn export
-      - run:
-          name: Copy static content and docker files to remote server
-          command: scp -r docker-compose.yml docker-compose.prod.yml .docker/ out/ $DEPLOY_USER@$DEPLOY_HOST:~/
 
   build-push-container:
     machine: true
@@ -79,14 +55,19 @@ jobs:
           name: Add key to known_hosts
           command: mkdir -p ~/ssh && ssh-keyscan $DEPLOY_HOST >> ~/.ssh/known_hosts
       - run:
-          name: Remotely pull docker images, then restart the container
+          name: Copy over Docker / Compose files to remote server
+          command: scp -r docker-compose.yml docker-compose.prod.yml .docker/ $DEPLOY_USER@$DEPLOY_HOST:~/
+      - run:
+          name: Remotely pull docker images, refresh, then restart the container
           command: |
             ssh -t $DEPLOY_USER@$DEPLOY_HOST "
-              docker pull matfin/cinematt:latest &&
-              docker stop cinematt &&
-              docker rm cinematt &&
+              docker pull matfin/cinematt-build:latest &&
+              docker pull matfin/cinematt-serve:latest &&
+              docker stop build serve &&
+              docker rm build serve &&
               docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
             "
+
 workflows:
   version: 2
   build_and_test:
@@ -95,13 +76,7 @@ workflows:
           filters:
             branches:
               ignore: main
-      - build-copy-files:
-          filters:
-            branches:
-              only: main
       - build-push-container:
-          requires:
-            - build-copy-files
           filters:
             branches:
               only: main

--- a/.docker/next/Dockerfile
+++ b/.docker/next/Dockerfile
@@ -1,0 +1,10 @@
+FROM      node:12.18-alpine
+RUN       mkdir -p /opt/build/node_modules && chown -R node:node /opt/build
+USER      node
+WORKDIR   /opt/build
+COPY      package.json yarn.lock ./
+RUN       yarn cache clean
+RUN       yarn
+COPY      --chown=node:node . .
+RUN       yarn build
+RUN       yarn export

--- a/.docker/nginx/Dockerfile
+++ b/.docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
 FROM      nginx:alpine
 RUN       mkdir -p /opt/public
 RUN       rm /etc/nginx/conf.d/default.conf
-COPY      templates/nginx.conf.template /etc/nginx/templates/nginx.conf.template
+COPY      .docker/nginx/templates/nginx.conf.template /etc/nginx/templates/nginx.conf.template

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
-# Ignore everything
-**
-
-# Exceptions
-!/out/**
-!/.docker/**
+*.MD
+LICENSE
+.circleci
+.git
+.vscode
+coverage
+docker-compose.yml
+docker-compose.prod.yml
+node_modules

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,11 @@
 version: '3'
 
 services:
-  nginx:
+  serve:
     environment:
       - NGINX_HOST=cinematt.com
       - SSL_CERTIFICATE=fullchain.pem
       - SSL_CERTIFICATE_KEY=privkey.pem
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt:ro
+      - static-content:/opt/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,21 @@
 version: '3'
 
 services:
-  nginx:
-    container_name: cinematt
-    image: matfin/cinematt:latest
+  build:
+    container_name: build
+    image: matfin/cinematt-build:latest
     build:
-      context: .docker/nginx
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: .docker/next/Dockerfile
+    volumes:
+      - static-content:/opt/build/out
+
+  serve:
+    container_name: serve
+    image: matfin/cinematt-serve:latest
+    build:
+      context: .
+      dockerfile: .docker/nginx/Dockerfile
     environment:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
       - NGINX_HOST=cinematt.build
@@ -16,6 +25,9 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./out/:/opt/public:ro
       - ~/ssl/letsencrypt:/etc/letsencrypt:ro
+      - static-content:/opt/public
     command: nginx -g "daemon off;"
+
+volumes:
+  static-content:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What is this?

This is a big refactor of the build and deploy process to make it simpler and more streamlined. Here is how it works.

- Another service has been added to the Docker Compose set up to statically build the NextJS project.
- The static content from this is stored in a volume, which is accessible by the Nginx service
- When Docker Compose builds, this is when the static content is built and, upon completion, the build container stops.
- When Docker Compose runs, the Nginx container is run. The build container remains shut down.
- Both these containers share a volume, so we can persist data between them and we no longer need to keep it on the host filesystem.
- With this, we reduce the number of steps that need to happen in the deployment process with CircleCI and things are much simpler and less error-prone.