### PR TITLE
fix: correct docker deployment to ensure latest files are used

### DIFF
--- a/.docker/next/Dockerfile
+++ b/.docker/next/Dockerfile
@@ -1,10 +1,8 @@
 FROM      node:12.18-alpine
-RUN       mkdir -p /opt/build/node_modules && chown -R node:node /opt/build
+RUN       mkdir -p /opt/build/node_modules /opt/build/out && chown -R node:node /opt/build
 USER      node
 WORKDIR   /opt/build
 COPY      package.json yarn.lock ./
 RUN       yarn cache clean
 RUN       yarn
 COPY      --chown=node:node . .
-RUN       yarn build
-RUN       yarn export

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,4 +8,4 @@ services:
       - SSL_CERTIFICATE_KEY=privkey.pem
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt:ro
-      - static-content:/opt/public
+      - static-content:/opt/public:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       dockerfile: .docker/next/Dockerfile
     volumes:
       - static-content:/opt/build/out
+    command: yarn deploy
 
   serve:
     container_name: serve
@@ -26,7 +27,7 @@ services:
       - "443:443"
     volumes:
       - ~/ssl/letsencrypt:/etc/letsencrypt:ro
-      - static-content:/opt/public
+      - static-content:/opt/public:ro
     command: nginx -g "daemon off;"
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "checks": "yarn coverage && yarn lint",
     "dev": "next",
+    "deploy": "yarn build && yarn export",
     "export": "next export",
     "build": "next build",
     "lint": "eslint '*/**/*.{js,ts,tsx}'",


### PR DESCRIPTION
## What is this?
This is a fix to ensure that the Docker containers contain the most up to date builds. The NextJS build pipeline is executed when the containers are started, as opposed to when they are built.