### PR TITLE
fix: correct characters for nextjs static content export

### DIFF
--- a/assets/photos/all.json
+++ b/assets/photos/all.json
@@ -170,7 +170,7 @@
     },
     {
       "asset_id":"8e78da5928a22e0fb876dbcbb5f0a078",
-      "public_id":"people/li-kindl-stu\u0308ben",
+      "public_id":"people/li-kindl-stuben",
       "format":"tiff",
       "version":1520972263,
       "resource_type":"image",
@@ -296,7 +296,7 @@
     },
     {
       "asset_id":"a3a902ec8598edf94aad97a14993e465",
-      "public_id":"people/beach-party-arainn-mho\u0301r",
+      "public_id":"people/beach-party-arainn-mhor",
       "format":"tiff",
       "version":1520779690,
       "resource_type":"image",
@@ -380,7 +380,7 @@
     },
     {
       "asset_id":"cd5b3532d295d6b803589b68f156acd3",
-      "public_id":"experimental/va\u0308ttern-gra\u0308nna",
+      "public_id":"experimental/vattern-granna",
       "format":"tiff",
       "version":1520761019,
       "resource_type":"image",
@@ -436,7 +436,7 @@
     },
     {
       "asset_id":"1451bcd6dec3672322d569454029c6e0",
-      "public_id":"landscapes/o\u0308resund-bridge",
+      "public_id":"landscapes/oresund-bridge",
       "format":"tiff",
       "version":1520757646,
       "resource_type":"image",

--- a/assets/photos/experimental.json
+++ b/assets/photos/experimental.json
@@ -55,7 +55,7 @@
   },
   {
     "height": 1440,
-    "publicId": "experimental/vättern-gränna",
+    "publicId": "experimental/vattern-granna",
     "version": 1520761019,
     "width": 2560
   },

--- a/assets/photos/landscapes.json
+++ b/assets/photos/landscapes.json
@@ -25,7 +25,7 @@
   },
   {
     "height": 1440,
-    "publicId": "landscapes/öresund-bridge",
+    "publicId": "landscapes/oresund-bridge",
     "version": 1520757646,
     "width": 2560
   },

--- a/assets/photos/people.json
+++ b/assets/photos/people.json
@@ -31,7 +31,7 @@
   },
   {
     "height": 1696,
-    "publicId": "people/li-kindl-stüben",
+    "publicId": "people/li-kindl-stuben",
     "version": 1520972263,
     "width": 2560
   },
@@ -67,7 +67,7 @@
   },
   {
     "height": 1440,
-    "publicId": "people/beach-party-arainn-mhór",
+    "publicId": "people/beach-party-arainn-mhor",
     "version": 1520779690,
     "width": 2560
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What is this?
This is a small fix that corrects a 404 that is raised when the export process for static content is not correctly output for files with accented characters.

As a temporary fix, these character accents (such as li-kindl-stüben) have been replaced. Once I can dig into the real problem, they will be restored, but this is a stop gap measure to fix 404s on photo detail views.