### PR TITLE
refactor: set up path aliasing for module imports

### DIFF
--- a/components/gallery/gallery.css.tsx
+++ b/components/gallery/gallery.css.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
-import { Orientation } from '../../types';
-import { media } from '../../styles/mixins';
+import { Orientation } from 'models/types';
+import { media } from 'styles/mixins';
 
 interface LinkProps {
   orientation: Orientation;

--- a/components/gallery/gallery.spec.tsx
+++ b/components/gallery/gallery.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { Photo } from '../../interfaces';
-import { Orientation } from '../../types';
+import { Photo } from 'models/interfaces';
+import { Orientation } from 'models/types';
 import Gallery, { Props } from './gallery';
 
 describe('Gallery tests', (): void => {

--- a/components/gallery/gallery.tsx
+++ b/components/gallery/gallery.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
-import { Photo } from '../../interfaces';
-import Picture from '../../components/picture/picture';
+import { Photo } from 'models/interfaces';
+import Picture from 'components/picture/picture';
 import { Container, LinkSt } from './gallery.css';
 
 export interface Props {

--- a/components/header/header.css.tsx
+++ b/components/header/header.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { colours, fontSizes, fontWeights } from '../../styles';
+import { colours, fontSizes, fontWeights } from 'styles';
 import MenuButton from '../menubutton/menubutton';
 
 const arrowLine = css`

--- a/components/layout/layout.css.tsx
+++ b/components/layout/layout.css.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { animationCurve, colours, layers } from '../../styles';
-import Header from '../header/header';
-import Navigation from '../navigation/navigation';
+import { animationCurve, colours, layers } from 'styles';
+import Header from 'components/header/header';
+import Navigation from 'components/navigation/navigation';
 
 interface NavProps {
   isRevealed: boolean;

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Head from 'next/head';
 import { MDXProvider } from '@mdx-js/react';
-import { components, GlobalStyle } from '../../styles';
+import { components, GlobalStyle } from 'styles';
 import { Container, LayoutHeader, Main, Nav } from './layout.css';
 
 export interface Props {

--- a/components/loading/loading.css.tsx
+++ b/components/loading/loading.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css, keyframes, Keyframes } from 'styled-components';
-import { colours } from '../../styles';
+import { colours } from 'styles';
 
 export enum Direction {
   UP = 'UP',

--- a/components/menubutton/menubutton.css.tsx
+++ b/components/menubutton/menubutton.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
-import { animationCurve, colours } from '../../styles';
+import { animationCurve, colours } from 'styles';
 
 export enum LinePlacement {
   TOP = 'top',

--- a/components/navigation/navigation.css.tsx
+++ b/components/navigation/navigation.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { animationCurve, colours, text } from '../../styles';
+import { animationCurve, colours, text } from 'styles';
 
 interface LinkTextProps {
   isActive: boolean;

--- a/components/navigation/navigation.tsx
+++ b/components/navigation/navigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { albums } from '../../config';
+import { albums } from 'config';
 import { LinkTextSt, Nav, NavItemList } from './navigation.css';
 
 export interface Props {

--- a/components/picture/picture.css.tsx
+++ b/components/picture/picture.css.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
-import { animationCurve, colours } from '../../styles';
-import Loading from '../loading/loading';
+import { animationCurve, colours } from 'styles';
+import Loading from 'components/loading/loading';
 
 interface ImageProps {
   hasLoaded: boolean;

--- a/components/picture/picture.spec.tsx
+++ b/components/picture/picture.spec.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import 'jest-styled-components';
 import { act, fireEvent, render } from '@testing-library/react';
-import { intersectionObserverMock } from '../../testutils';
-import { Orientation } from '../../types';
+import { intersectionObserverMock } from 'testutils';
 import Picture, { altText, Props } from './picture';
 
 describe('Picture tests', () => {
   const defaultProps: Props = {
-    orientation: Orientation.Landscape,
     publicId: '123',
     version: '456',
   };

--- a/components/picture/picture.tsx
+++ b/components/picture/picture.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useCallback, useRef, useState, useEffect } from 'react';
-import { PictureSourceSize } from '../../interfaces';
-import { resourceBaseUrl, detailSourceMediaQueries, tileSourceMediaQueries } from '../../config';
-import useIntersectionObserver from '../../hooks/useIntersectionObserver';
+import { PictureSourceSize } from 'models/interfaces';
+import { resourceBaseUrl, detailSourceMediaQueries, tileSourceMediaQueries } from 'config';
+import useIntersectionObserver from 'hooks/useIntersectionObserver';
 import { Image, LoadingStrip, PictureContainer } from './picture.css';
 
 interface PictureSourcesProps {

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-import { PictureSourceSize } from './interfaces';
+import { PictureSourceSize } from 'models/interfaces';
 
 export const albums: string[] = [
   'abandoned', 'people', 'music',

--- a/hooks/hooks.test.tsx
+++ b/hooks/hooks.test.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { render } from '@testing-library/react';
 import useIntersectionObserver from './useIntersectionObserver';
-import { intersectionObserverMock } from '../testutils';
+import { intersectionObserverMock } from 'testutils';
 
 describe('userIntersectionObserver tests', () => {
   const spyDisconnect = jest.fn();

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,15 @@ module.exports = {
     'testutils.ts',
   ],
   moduleDirectories: ['node_modules'],
+  moduleNameMapper: {
+    '^assets/(.*)$': '<rootDir>/assets/$1',
+    '^components/(.*)$': '<rootDir>/components/$1',
+    '^hooks/(.*)$': '<rootDir>/hooks/$1',
+    '^lib/(.*)$': '<rootDir>/lib/$1',
+    '^models/(.*)$': '<rootDir>/models/$1',
+    '^pages/(.*)$': '<rootDir>/pages/$1',
+    '^styles/(.*)$': '<rootDir>/styles/$1',
+    '^(config|styles|testutils)$': '<rootDir>/$1',
+  },
   testEnvironment: 'jest-environment-jsdom-sixteen'
 };

--- a/lib/albums.ts
+++ b/lib/albums.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
-import { albums } from '../config';
-import { AlbumParam, Photo, PictureParam } from '../interfaces';
-import { Orientation } from '../types';
+import { albums } from 'config';
+import { AlbumParam, Photo, PictureParam } from 'models/interfaces';
+import { Orientation } from 'models/types';
 
 export const getAlbumSlugs = (): AlbumParam[] => {
   return albums.map(

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Orientation } from './types';
 
 export interface IntersectionObserverMockProps {
@@ -10,19 +11,19 @@ export interface IntersectionObserverMockProps {
 export interface AlbumParam {
   params: {
     slug: string;
-  }
+  };
 }
 
 export interface PictureParam {
   params: {
     publicId: string;
     slug: string;
-  }
+  };
 }
 
 export interface Photo {
   height: number;
-  orientation: Orientation,
+  orientation: Orientation;
   publicId: string;
   version: string;
   width: number;
@@ -41,11 +42,11 @@ export interface StaticPaths {
 export interface StaticAlbumProps {
   props: {
     photos: Photo[];
-  }
+  };
 }
 
 export interface StaticPhotoProps {
   props: {
     photo?: Photo;
-  }
+  };
 }

--- a/models/types.ts
+++ b/models/types.ts
@@ -4,34 +4,34 @@ export type Breakpoints = {
   lg: number;
   xl: number;
   xxl: number;
-}
+};
 
 export type Colours = {
   primary: string;
   secondary: string;
   tertiary: string;
-}
+};
 
 export type FontSizes = {
   normal: number;
   larger: number;
   largest: number;
-}
+};
 
 export type FontWeights = {
   light: number;
   medium: number;
   heavy: number;
-}
+};
 
 export type Layers = {
   base: number;
   over: number;
   top: number;
   under: number;
-}
+};
 
 export enum Orientation {
   Landscape = 'landscape',
-  Portrait = 'portrait'
+  Portrait = 'portrait',
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Layout from '../components/layout/layout';
-import Content from '../assets/pages/about.md';
-import { Container } from '../styles/pages/about.css';
+import Layout from 'components/layout/layout';
+import Content from 'assets/pages/about.md';
+import { Container } from 'styles/pages/about.css';
 
 const About = (): JSX.Element => (
   <Layout>

--- a/pages/albums/[slug]/[publicId].tsx
+++ b/pages/albums/[slug]/[publicId].tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Photo, PictureParam, StaticPaths, StaticPhotoProps } from '../../../interfaces';
-import Layout from '../../../components/layout/layout';
-import { getPhoto, getPhotoPublicIds } from '../../../lib/albums';
-import { Container, PictureSt } from '../../../styles/pages/picturedetail.css';
+import { Photo, PictureParam, StaticPaths, StaticPhotoProps } from 'models/interfaces';
+import Layout from 'components/layout/layout';
+import { getPhoto, getPhotoPublicIds } from 'lib/albums';
+import { Container, PictureSt } from 'styles/pages/picturedetail.css';
 
 interface Props {
   photo: Photo;

--- a/pages/albums/[slug]/index.tsx
+++ b/pages/albums/[slug]/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { AlbumParam, Photo, StaticAlbumProps, StaticPaths } from '../../../interfaces';
-import Gallery from '../../../components/gallery/gallery';
-import Layout from '../../../components/layout/layout';
-import { getAlbumSlugs, getPhotos } from '../../../lib/albums';
+import { AlbumParam, Photo, StaticAlbumProps, StaticPaths } from 'models/interfaces';
+import Gallery from 'components/gallery/gallery';
+import Layout from 'components/layout/layout';
+import { getAlbumSlugs, getPhotos } from 'lib/albums';
 
 interface Props {
   photos: Photo[];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Photo, StaticAlbumProps } from '../interfaces';
-import Gallery from '../components/gallery/gallery';
-import Layout from '../components/layout/layout';
-import { getPhotos } from '../lib/albums';
+import { Photo, StaticAlbumProps } from 'models/interfaces';
+import Gallery from 'components/gallery/gallery';
+import Layout from 'components/layout/layout';
+import { getPhotos } from 'lib/albums';
 
 interface Props {
   photos: Photo[];

--- a/styles/pages/about.css.tsx
+++ b/styles/pages/about.css.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { breakpoints, components } from '../';
+import { breakpoints, components } from 'styles';
 
 export const Container = styled.div`
   padding: 1rem 1rem 4rem 1rem;

--- a/styles/pages/picturedetail.css.tsx
+++ b/styles/pages/picturedetail.css.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Picture from '../../components/picture/picture';
+import Picture from 'components/picture/picture';
 
 interface ContainerProps {
   photoHeight: number;

--- a/styles/vars.ts
+++ b/styles/vars.ts
@@ -1,4 +1,4 @@
-import { Breakpoints, Colours, FontSizes, FontWeights, Layers } from '../types';
+import { Breakpoints, Colours, FontSizes, FontWeights, Layers } from 'types';
 
 export const defaultFont = 'Gill Sans,Gill Sans MT,Calibri,sans-serif';
 

--- a/testutils.ts
+++ b/testutils.ts
@@ -1,4 +1,4 @@
-import { IntersectionObserverMockProps } from './interfaces';
+import { IntersectionObserverMockProps } from 'models/interfaces';
 
 export const intersectionObserverMock = ({ disconnect, observe, observerEntries, unobserve }: IntersectionObserverMockProps): void => {
   class IntersectionObserver {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,15 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "assets/*": ["assets/*"],
+      "components/*": ["components/*"],
+      "hooks/*": ["hooks/*"],
+      "lib/*": ["lib/*"],
+      "models/*": ["models/*"],
+      "pages/*": ["pages/*"],
+      "styles/*": ["styles/*"]
+    },
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
## What is this?
This is a PR to implement path aliasing for module imports, so:

`import { something } from '../../../../components/something';'`

will become `import { something } from 'components/something';` which is much neater.