### PR TITLE
feat: add touch support for menu button

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
     '^models/(.*)$': '<rootDir>/src/models/$1',
     '^pages/(.*)$': '<rootDir>/src/pages/$1',
     '^styles/(.*)$': '<rootDir>/src/styles/$1',
-    '^(config|styles|testutils)$': '<rootDir>/src/$1',
+    '^(config|styles|testutils|utils)$': '<rootDir>/src/$1',
   },
   testEnvironment: 'jest-environment-jsdom-sixteen'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {

--- a/src/components/menubutton/menubutton.spec.tsx
+++ b/src/components/menubutton/menubutton.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { fireEvent, render } from '@testing-library/react';
+import * as utils from 'utils';
 import MenuButton, { Props } from './menubutton';
 
 describe('MenuButton tests', (): void => {
@@ -8,6 +9,15 @@ describe('MenuButton tests', (): void => {
     isOpen: false,
     onClick: jest.fn(),
   };
+  const spyShouldUseTouch = jest.spyOn(utils, 'isTouchDevice');
+
+  beforeEach((): void => {
+    spyShouldUseTouch.mockReturnValue(false);
+  });
+
+  afterAll((): void => {
+    spyShouldUseTouch.mockRestore();
+  });
 
   it('renders the component', (): void => {
     expect(render(<MenuButton {...defaultProps} />)).toBeTruthy();
@@ -18,10 +28,29 @@ describe('MenuButton tests', (): void => {
     const { container } = render(<MenuButton {...defaultProps} onClick={spyOnClick} />);
     const button = container.querySelector('button');
 
-    act((): void => {
-      fireEvent.click(button);
-    });
+    await act(
+      async (): Promise<void> => {
+        fireEvent.click(button);
+        fireEvent.touchStart(button);
+      },
+    );
 
-    await expect(spyOnClick).toHaveBeenCalled();
+    await expect(spyOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes the callback on touch', async (): Promise<void> => {
+    spyShouldUseTouch.mockReturnValue(true);
+    const spyOnClick = jest.fn();
+    const { container } = render(<MenuButton {...defaultProps} onClick={spyOnClick} />);
+    const button = container.querySelector('button');
+
+    await act(
+      async (): Promise<void> => {
+        fireEvent.click(button);
+        fireEvent.touchStart(button);
+      },
+    );
+
+    await expect(spyOnClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/menubutton/menubutton.tsx
+++ b/src/components/menubutton/menubutton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isTouchDevice } from 'utils';
 import { Container, Line, LinePlacement } from './menubutton.css';
 
 export interface Props {
@@ -7,12 +8,24 @@ export interface Props {
   onClick: (e: React.MouseEvent | React.TouchEvent) => void;
 }
 
-const MenuButton = ({ className, isOpen, onClick }: Props): JSX.Element => (
-  <Container aria-label="Menu" className={className} onClick={onClick}>
-    <Line placement={LinePlacement.TOP} isOpen={isOpen} />
-    <Line placement={LinePlacement.MIDDLE} isOpen={isOpen} />
-    <Line placement={LinePlacement.BOTTOM} isOpen={isOpen} />
-  </Container>
-);
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {};
+
+const MenuButton = ({ className, isOpen, onClick }: Props): JSX.Element => {
+  const shouldUseTouch: boolean = isTouchDevice();
+
+  return (
+    <Container
+      aria-label="Menu"
+      className={className}
+      onClick={!shouldUseTouch ? onClick : noop}
+      onTouchStart={shouldUseTouch ? onClick : noop}
+    >
+      <Line placement={LinePlacement.TOP} isOpen={isOpen} />
+      <Line placement={LinePlacement.MIDDLE} isOpen={isOpen} />
+      <Line placement={LinePlacement.BOTTOM} isOpen={isOpen} />
+    </Container>
+  );
+};
 
 export default MenuButton;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,1 @@
+export const isTouchDevice = (): boolean => typeof window !== 'undefined' && 'ontouchstart' in window;


### PR DESCRIPTION
## What is this?
This PR adds touch support for the menu button where available, for a more responsive user experience. If touch is not supported, the click event is used by default.