### PR TITLE
feat: photo detail view now contains navigation links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {

--- a/src/components/footernav/footernav.css.tsx
+++ b/src/components/footernav/footernav.css.tsx
@@ -1,0 +1,58 @@
+import styled, { css } from 'styled-components';
+import { media, text } from 'styles';
+import { GridIcon } from 'components/icons';
+
+const buttonStyle = `
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  font-size: 2rem;
+`;
+
+export const Container = styled.footer`
+  display: flex;
+  justify-content: space-between;
+
+  ${media.md(css`
+    justify-content: center;
+  `)}
+`;
+
+export const Navigation = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const Back = styled.a`
+  ${buttonStyle};
+
+  &::before {
+    content: '<';
+  }
+`;
+
+export const Forward = styled.a`
+  ${buttonStyle};
+
+  &::after {
+    content: '>';
+  }
+`;
+
+export const Details = styled.span`
+  ${text};
+`;
+
+export const Grid = styled(GridIcon)`
+  width: 5rem;
+  height: 2rem;
+`;
+
+export const GridLink = styled.a`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/footernav/footernav.test.tsx
+++ b/src/components/footernav/footernav.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Photo } from 'models/interfaces';
+import { Orientation } from 'models/types';
+import FooterNav, { Props } from './footernav';
+
+const photos: Photo[] = [
+  {
+    name: 'test-photo-one',
+    album: 'test',
+    public_id: 'test/test-photo-one',
+    format: 'jpg',
+    version: '123',
+    created_at: new Date('1982-04-26'),
+    width: 1024,
+    height: 768,
+    tags: [],
+    orientation: Orientation.Landscape,
+  },
+  {
+    name: 'test-photo-two',
+    album: 'test',
+    public_id: 'test/test-photo-two',
+    format: 'jpg',
+    version: '456',
+    created_at: new Date('1982-04-26'),
+    width: 1024,
+    height: 768,
+    tags: [],
+    orientation: Orientation.Landscape,
+  },
+  {
+    name: 'test-photo-three',
+    album: 'test',
+    public_id: 'test/test-photo-three',
+    format: 'jpg',
+    version: '789',
+    created_at: new Date('1982-04-26'),
+    width: 1024,
+    height: 768,
+    tags: [],
+    orientation: Orientation.Landscape,
+  },
+];
+
+const defaultProps: Props = {
+  album: {
+    name: 'test',
+    photos,
+  },
+  currentPhoto: photos[1],
+};
+
+describe('Footer nav', (): void => {
+  it('renders the component', (): void => {
+    expect(render(<FooterNav {...defaultProps} />)).toBeTruthy();
+  });
+
+  it('renders the correct navigation details and links', (): void => {
+    const { container } = render(<FooterNav {...defaultProps} />);
+
+    expect(container.querySelector('span').textContent).toEqual('2 of 3');
+    expect(container.querySelectorAll('a')[0].href).toContain('/albums/test/test-photo-one');
+    expect(container.querySelectorAll('a')[1].href).toContain('/albums/test/test-photo-three');
+  });
+
+  it('renders a link to the first photo if the current one is the last', (): void => {
+    const props: Props = {
+      ...defaultProps,
+      currentPhoto: photos[2],
+    };
+    const { container } = render(<FooterNav {...props} />);
+
+    expect(container.querySelector('span').textContent).toEqual('3 of 3');
+    expect(container.querySelectorAll('a')[0].href).toContain('/albums/test/test-photo-two');
+    expect(container.querySelectorAll('a')[1].href).toContain('/albums/test/test-photo-one');
+  });
+
+  it('renders a link to the last photo if the current one is the first', (): void => {
+    const props: Props = {
+      ...defaultProps,
+      currentPhoto: photos[0],
+    };
+    const { container } = render(<FooterNav {...props} />);
+
+    expect(container.querySelector('span').textContent).toEqual('1 of 3');
+    expect(container.querySelectorAll('a')[0].href).toContain('/albums/test/test-photo-three');
+    expect(container.querySelectorAll('a')[1].href).toContain('/albums/test/test-photo-two');
+  });
+});

--- a/src/components/footernav/footernav.tsx
+++ b/src/components/footernav/footernav.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Link from 'next/link';
+import { Album, Photo } from 'models/interfaces';
+import { Back, Container, Details, Forward, Grid, GridLink, Navigation } from './footernav.css';
+
+export interface Props {
+  album: Album;
+  className?: string;
+  currentPhoto: Photo;
+}
+
+const urlFromPhoto = ({ public_id }: Photo): string => `/albums/${public_id}`;
+
+const FooterNav = ({ album, className, currentPhoto }: Props): JSX.Element => {
+  const { photos, name } = album;
+  const photoCount: number = photos.length;
+  const currentIndex: number = photos.findIndex(({ public_id }: Photo) => public_id === currentPhoto.public_id);
+  const firstPhoto: Photo = photos[0];
+  const lastPhoto: Photo = photos[photos.length - 1];
+  const nextPhoto: Photo | undefined = photos[currentIndex + 1];
+  const prevPhoto: Photo | undefined = photos[currentIndex - 1];
+  const backUrl: string = urlFromPhoto(prevPhoto ?? lastPhoto);
+  const forwardUrl: string = urlFromPhoto(nextPhoto ?? firstPhoto);
+
+  return (
+    <Container className={className}>
+      <Navigation>
+        <Link as={backUrl} href="/albums/[albumName]/[public_id]" passHref>
+          <Back />
+        </Link>
+        <Details>
+          {currentIndex + 1} of {photoCount}
+        </Details>
+        <Link as={forwardUrl} href="/albums/[albumName]/[public_id]" passHref>
+          <Forward />
+        </Link>
+      </Navigation>
+      <Link as={`/albums/${name}`} href="/albums/[albumName]" passHref>
+        <GridLink>
+          <Grid />
+        </GridLink>
+      </Link>
+    </Container>
+  );
+};
+
+export default FooterNav;

--- a/src/components/gallery/gallery.tsx
+++ b/src/components/gallery/gallery.tsx
@@ -16,7 +16,12 @@ const Gallery = ({ className, photos }: Props): JSX.Element => (
       const isProminent: boolean = tags.includes('prominent');
 
       return (
-        <Link as={`/albums/${public_id}`} href="/albums/[albumName]/[public_id]" key={`${public_id}-${version}`}>
+        <Link
+          as={`/albums/${public_id}`}
+          href="/albums/[albumName]/[public_id]"
+          key={`${public_id}-${version}`}
+          passHref
+        >
           <LinkSt isProminent={isProminent} orientation={orientation}>
             <Picture lazyLoad photo={photo} />
           </LinkSt>

--- a/src/components/header/header.css.tsx
+++ b/src/components/header/header.css.tsx
@@ -1,30 +1,20 @@
-import styled, { css } from 'styled-components';
-import { colours, fontSizes, fontWeights } from 'styles';
+import styled from 'styled-components';
+import { dimensions, fontSizes, fontWeights } from 'styles';
 import MenuButton from '../menubutton/menubutton';
-
-const arrowLine = css`
-  position: absolute;
-  width: 1.5rem;
-  left: 1rem;
-  height: 0.125rem;
-  background: ${colours.primary};
-  content: '';
-  transform-origin: right;
-`;
 
 export const Container = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-direction: row;
-  padding: 0 1rem;
   backdrop-filter: blur(4px);
 `;
 
 export const Title = styled.h1`
   font-size: ${fontSizes.largest}rem;
   font-weight: ${fontWeights.light};
-  line-height: 5rem;
+  line-height: ${dimensions.navigationHeight}rem;
+  margin-left: 1rem;
 `;
 
 export const Button = styled(MenuButton)`
@@ -33,19 +23,15 @@ export const Button = styled(MenuButton)`
 `;
 
 export const BackButton = styled.span`
-  width: 2rem;
-  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: ${dimensions.navigationHeight}rem;
+  font-size: 2rem;
 
   &::before {
-    ${arrowLine};
-    top: 1.75rem;
-    transform: rotate(-28deg);
-  }
-
-  &::after {
-    ${arrowLine};
-    bottom: 1.75rem;
-    transform: rotate(28deg);
+    content: '<';
   }
 `;
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -18,7 +18,7 @@ const Header = ({ className, navRevealed, onMenuButtonClick, onTitleClick }: Pro
   return (
     <Container className={className}>
       {public_id ? (
-        <Link href="/albums/[albumName]" as={`/albums/${albumName}`}>
+        <Link href="/albums/[albumName]" as={`/albums/${albumName}`} passHref>
           <BackLink>
             <BackButton />
           </BackLink>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface Props {
+  className?: string;
+}
+
+export const GridIcon = ({ className }: Props): JSX.Element => (
+  <svg
+    className={className}
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    viewBox="0 0 100 100"
+    xmlSpace="preserve"
+  >
+    <g id="layer1">
+      <rect y="10" x="10" height="20" width="20" />
+      <rect height="20" width="20" x="40" y="10" />
+      <rect y="10" x="70" height="20" width="20" />
+
+      <rect height="20" width="20" x="10" y="40" />
+      <rect y="40" x="40" height="20" width="20" />
+      <rect height="20" width="20" x="70" y="40" />
+
+      <rect y="70" x="10" height="20" width="20" />
+      <rect height="20" width="20" x="40" y="70" />
+      <rect y="70" x="70" height="20" width="20" />
+    </g>
+  </svg>
+);

--- a/src/components/layout/layout.css.tsx
+++ b/src/components/layout/layout.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { animationCurve, colours, layers, media } from 'styles';
+import { animationCurve, colours, dimensions, layers, media } from 'styles';
 import Header from 'components/header/header';
 import Navigation from 'components/navigation/navigation';
 
@@ -9,9 +9,13 @@ interface NavProps {
 
 export const Container = styled.div`
   display: grid;
-  grid-template-rows: 5rem auto;
+  grid-template-rows:
+    ${dimensions.navigationHeight}rem minmax(auto, calc(100vh - ${dimensions.navigationHeight * 2}rem))
+    ${dimensions.navigationHeight}rem;
+
   grid-template-areas:
     'header'
+    'main'
     'main';
   overflow-x: hidden;
 `;
@@ -22,7 +26,7 @@ export const LayoutHeader = styled(Header)`
   top: 0;
   left: 0;
   width: 100vw;
-  height: 5rem;
+  height: ${dimensions.navigationHeight}rem;
   background: ${colours.secondaryOpaque};
 `;
 
@@ -33,9 +37,10 @@ export const Main = styled.main`
 export const Nav = styled(Navigation)<NavProps>`
   z-index: ${layers.over};
   position: fixed;
+  top: ${dimensions.navigationHeight}rem;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh - ${dimensions.navigationHeight}rem);
   background: ${colours.secondaryOpaque};
   backdrop-filter: blur(4px);
   transition: transform 350ms ${animationCurve};
@@ -48,7 +53,6 @@ export const Nav = styled(Navigation)<NavProps>`
     `};
 
   ${media.lg(css`
-    top: 5rem;
     width: 15rem;
 
     ${({ isRevealed }: NavProps) =>

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -8,7 +8,7 @@ import Meta from 'components/meta/meta';
 import { Container, LayoutHeader, Main, Nav } from './layout.css';
 
 export interface Props {
-  children?: JSX.Element;
+  children?: JSX.Element | JSX.Element[];
   titlePhoto?: Photo;
 }
 

--- a/src/components/loading/loading.css.tsx
+++ b/src/components/loading/loading.css.tsx
@@ -30,10 +30,6 @@ export const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
 `;
 
 export const Square = styled.div<SquareProps>`

--- a/src/components/navigation/navigation.css.tsx
+++ b/src/components/navigation/navigation.css.tsx
@@ -7,8 +7,8 @@ interface LinkTextProps {
 
 export const Nav = styled.nav`
   display: grid;
-  grid-template-rows: 6rem auto;
-  grid-template-columns: 1rem auto 1rem;
+  grid-template-rows: 4rem auto;
+  grid-template-columns: 1.5rem auto 1.5rem;
 
   ${media.lg(css`
     grid-template-rows: auto;

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -16,7 +16,7 @@ const AlbumLinks = (onClick: (e: React.MouseEvent | React.TouchEvent) => void, a
   albums.map(
     (albumName: string): JSX.Element => (
       <li key={albumName}>
-        <Link as={`/albums/${albumName}`} href="/albums/[albumName]">
+        <Link as={`/albums/${albumName}`} href="/albums/[albumName]" passHref>
           <LinkTextSt data-testid={albumName} isActive={routeMatches(`/albums/${albumName}`, asPath)} onClick={onClick}>
             {capitalise(albumName)}
           </LinkTextSt>
@@ -33,7 +33,7 @@ const Navigation = ({ className, onNavigate }: Props): JSX.Element => {
     <Nav className={className}>
       <NavItemList>
         <li>
-          <Link href="/">
+          <Link href="/" passHref>
             <LinkTextSt onClick={onNavigate} isActive={asPath === '/'}>
               Featured
             </LinkTextSt>
@@ -41,7 +41,7 @@ const Navigation = ({ className, onNavigate }: Props): JSX.Element => {
         </li>
         {AlbumLinks(onNavigate, asPath)}
         <li>
-          <Link href="/about">
+          <Link href="/about" passHref>
             <LinkTextSt isActive={asPath === '/about'} onClick={onNavigate}>
               About
             </LinkTextSt>

--- a/src/components/picture/picture.css.tsx
+++ b/src/components/picture/picture.css.tsx
@@ -1,59 +1,60 @@
-import styled, { css } from 'styled-components';
-import { Color } from 'models/interfaces';
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import { Orientation } from 'models/types';
 import { animationCurve } from 'styles';
 import Loading from 'components/loading/loading';
 
 interface ImageProps {
   hasLoaded: boolean;
+  isDetail: boolean;
+  orientation: Orientation;
 }
 
-interface PictureProps {
-  hasLoaded: boolean;
-  colors: Color[];
-}
+export const imageDimensions = (orientation: Orientation, isDetail: boolean): FlattenSimpleInterpolation => {
+  if (isDetail) {
+    return orientation === Orientation.Landscape
+      ? css`
+          width: 100%;
+          height: auto;
+        `
+      : css`
+          width: auto;
+          height: 100%;
+        `;
+  }
 
-export const gradient = (colors: Color[], start = 0, end = 5): string =>
-  colors
-    .slice(start, end)
-    .map(({ code }: Color): string => `${code}`)
-    .join(',');
+  return css`
+    width: 100%;
+    height: 100%;
+  `;
+};
 
-export const PictureContainer = styled.picture<PictureProps>`
-  position: relative;
-  display: block;
+export const PictureContainer = styled.picture`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
-  transition: border 350ms ${animationCurve};
-  ${({ colors }: PictureProps) => css`
-    background: linear-gradient(217deg, ${gradient(colors, 0, 5)});
-  `}
-
-  ${({ hasLoaded }) =>
-    hasLoaded &&
-    css`
-      background: none;
-    `}
 `;
 
 export const Image = styled.img<ImageProps>`
-  width: 100%;
-  height: 75%;
+  ${({ isDetail, orientation }) => imageDimensions(orientation, isDetail)};
   object-position: center;
   object-fit: cover;
   opacity: 0;
-  transition: opacity 350ms ${animationCurve};
+
+  ${({ isDetail }: ImageProps) =>
+    !isDetail &&
+    css`
+      transition: opacity 350ms ${animationCurve};
+    `}
 
   ${({ hasLoaded }) =>
     hasLoaded &&
     css`
-      height: 100%;
       opacity: 1;
     `};
 `;
 
 export const LoadingStrip = styled(Loading)`
-  position: absolute;
-  bottom: 0;
-  left: 0;
   width: 100%;
 `;

--- a/src/components/picture/picture.spec.tsx
+++ b/src/components/picture/picture.spec.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import 'jest-styled-components';
 import { act, fireEvent, render } from '@testing-library/react';
-import { Color } from 'models/interfaces';
 import { Orientation } from 'models/types';
 import { intersectionObserverMock } from 'testutils';
 import Picture, { altText, Props } from './picture';
-import { gradient } from './picture.css';
+import { imageDimensions } from './picture.css';
 
 describe('Picture tests', () => {
   const defaultProps: Props = {
@@ -77,13 +76,10 @@ describe('Picture tests', () => {
   });
 
   describe('picture styles', (): void => {
-    it('should return the correct gradient', (): void => {
-      const colors: Color[] = [
-        { code: '#fff', weight: 0.5 },
-        { code: '#ccc', weight: 0.25 },
-        { code: '#000', weight: 0.25 },
-      ];
-      expect(gradient(colors)).toEqual('#fff,#ccc,#000');
+    it('returns the correct style given display type and picture orientation', (): void => {
+      expect(imageDimensions(Orientation.Landscape, false)).toEqual(['width:100%;height:100%;']);
+      expect(imageDimensions(Orientation.Landscape, true)).toEqual(['width:100%;height:auto;']);
+      expect(imageDimensions(Orientation.Portrait, true)).toEqual(['width:auto;height:100%;']);
     });
   });
 });

--- a/src/components/picture/picture.tsx
+++ b/src/components/picture/picture.tsx
@@ -56,16 +56,19 @@ export const pictureSources = ({ isDetail, photo, shouldLoad }: PictureSourcesPr
 const Picture = ({ className, isDetail = false, lazyLoad = false, photo }: Props): JSX.Element => {
   const [hasLoaded, setHasLoaded] = useState<boolean>(false);
   const [shouldLoad, setShouldLoad] = useState<boolean>(false);
-  const { colors, public_id, version } = photo;
+  const { orientation, public_id, version } = photo;
   const imgSrc = `${resourceBaseUrl}/w_1280/v${version}/${public_id}.jpg`;
   const imgAlt = altText(public_id);
   const imgRef = useRef(null);
+
   const onImageLoad = useCallback((): void => {
     setHasLoaded(true);
   }, [public_id, version]);
 
   useIntersectionObserver(imgRef, (): void => {
-    setShouldLoad(true);
+    if (lazyLoad) {
+      setShouldLoad(true);
+    }
   });
 
   useEffect((): void => {
@@ -74,10 +77,22 @@ const Picture = ({ className, isDetail = false, lazyLoad = false, photo }: Props
     }
   }, [lazyLoad]);
 
+  useEffect((): void => {
+    setHasLoaded(false);
+  }, [photo]);
+
   return (
-    <PictureContainer className={className} colors={colors} hasLoaded={hasLoaded}>
+    <PictureContainer className={className}>
       {pictureSources({ isDetail, photo, shouldLoad })}
-      <Image alt={imgAlt} hasLoaded={hasLoaded} onLoad={onImageLoad} ref={imgRef} src={shouldLoad ? imgSrc : null} />
+      <Image
+        alt={imgAlt}
+        hasLoaded={hasLoaded}
+        isDetail={isDetail}
+        onLoad={onImageLoad}
+        orientation={orientation}
+        ref={imgRef}
+        src={shouldLoad ? imgSrc : null}
+      />
       {!hasLoaded && shouldLoad && <LoadingStrip />}
     </PictureContainer>
   );

--- a/src/lib/albums.ts
+++ b/src/lib/albums.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from 'fs';
 import { albums } from 'config';
 import { Album, AlbumParam, Photo } from 'models/interfaces';
-import { getPhoto } from 'lib/photos';
 import { Orientation } from 'models/types';
 
 export const getAlbumNames = (): AlbumParam[] => {
@@ -20,13 +19,10 @@ export const getAlbum = async (name: string): Promise<Album | null> => {
   try {
     const content: string = await fs.readFile(filePath, 'utf-8');
     const { name, photos }: Album = JSON.parse(content);
-    const photosWithDetail: Photo[] = await Promise.all(
-      photos.map(({ public_id }: Photo): Promise<Photo> => getPhoto(public_id)),
-    );
 
     return {
       name,
-      photos: photosWithDetail.map(
+      photos: photos.map(
         (photo: Photo): Photo => ({
           ...photo,
           orientation: photo.width > photo.height ? Orientation.Landscape : Orientation.Portrait,

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -67,6 +67,7 @@ export interface StaticAlbumProps {
 
 export interface StaticPhotoProps {
   props: {
+    album?: Album;
     photo?: Photo;
   };
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -7,6 +7,10 @@ export type Breakpoints = {
   xxl: number;
 };
 
+export type Dimensions = {
+  navigationHeight: number;
+};
+
 export type Colours = {
   primary: string;
   secondary: string;

--- a/src/pages/albums/[albumName]/[public_id].tsx
+++ b/src/pages/albums/[albumName]/[public_id].tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { Photo, PictureParam, StaticPaths, StaticPhotoProps } from 'models/interfaces';
+import { Album, Photo, PictureParam, StaticPaths, StaticPhotoProps } from 'models/interfaces';
 import Layout from 'components/layout/layout';
 import { getPhoto, getPhotoPublicIds } from 'lib/photos';
-
-import { Container, PictureSt } from 'styles/pages/picturedetail.css';
+import { getAlbum } from 'lib/albums';
+import { Container, FooterNavigation, PictureSt } from 'styles/pages/picturedetail.css';
 
 interface Props {
+  album: Album;
   photo: Photo;
 }
 
-const PictureDetail = ({ photo }: Props): JSX.Element => (
+const PictureDetail = ({ album, photo }: Props): JSX.Element => (
   <Layout titlePhoto={photo}>
-    <Container photoHeight={photo.height}>
+    <Container>
       <PictureSt isDetail lazyLoad photo={photo} />
     </Container>
+    <FooterNavigation album={album} currentPhoto={photo} />
   </Layout>
 );
 
@@ -26,9 +28,11 @@ export async function getStaticPaths(): Promise<StaticPaths> {
 export async function getStaticProps({ params }: PictureParam): Promise<StaticPhotoProps> {
   const { albumName, public_id } = params;
   const photo: Photo | null = await getPhoto(`${albumName}/${public_id}`);
+  const album: Album | null = await getAlbum(albumName);
 
   return {
     props: {
+      album,
       photo,
     },
   };

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -38,6 +38,7 @@ export const GlobalStyle = createGlobalStyle`
     border: none;
     background-color: inherit;
     -webkit-tap-highlight-color: transparent;
+
     &:focus {
       outline: 0;
     }

--- a/src/styles/pages/picturedetail.css.tsx
+++ b/src/styles/pages/picturedetail.css.tsx
@@ -1,20 +1,37 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { breakpoints, dimensions, colours, media } from 'styles';
 import Picture from 'components/picture/picture';
+import { Image } from 'components/picture/picture.css';
+import FooterNav from 'components/footernav/footernav';
 
-interface ContainerProps {
-  photoHeight: number;
-}
+export const Container = styled.div`
+  ${media.base(
+    css`
+      position: fixed;
+      top: ${dimensions.navigationHeight}rem;
+      left: 0;
+      bottom: ${dimensions.navigationHeight}rem;
+      right: 0;
+    `,
+    breakpoints.lg,
+  )}
 
-export const Container = styled.div<ContainerProps>`
-  display: flex;
-  height: calc(100vh - 160px);
+  ${media.lg(css`
+    height: calc(100vh - ${dimensions.navigationHeight * 2}rem);
+  `)}
 `;
 
 export const PictureSt = styled(Picture)`
-  width: 100%;
-  height: auto;
-
-  img {
+  ${Image} {
     object-fit: contain;
   }
+`;
+
+export const FooterNavigation = styled(FooterNav)`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  height: ${dimensions.navigationHeight}rem;
+  background: ${colours.secondaryOpaque};
 `;

--- a/src/styles/vars.ts
+++ b/src/styles/vars.ts
@@ -1,4 +1,4 @@
-import { Breakpoints, Colours, FontSizes, FontWeights, Layers } from '../models/types';
+import { Breakpoints, Colours, Dimensions, FontSizes, FontWeights, Layers } from '../models/types';
 
 export const defaultFont = 'Gill Sans,Gill Sans MT,Calibri,sans-serif';
 
@@ -35,6 +35,10 @@ export const layers: Layers = {
   over: 2,
   top: 3,
   under: -1,
+};
+
+export const dimensions: Dimensions = {
+  navigationHeight: 5,
 };
 
 export const animationCurve = 'cubic-bezier(0.91, 0.03, 0.12, 1)';


### PR DESCRIPTION
## What is this?
This is a refactor of the photo detail view to allow for the following:
- footer navigation added to the photo detail view to go to the next and previous photo to the current one
- styling for displaying photos on mobile devices has been improved
- links now have the `href` prop added to them
- 'grid' icon added in the footer navigation
- the album view no longer fetches the details for each photo
- colour gradients on loading have been removed