### PR TITLE
feat: add keyboard arrow navigation for photos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {

--- a/src/components/footernav/footernav.tsx
+++ b/src/components/footernav/footernav.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Album, Photo } from 'models/interfaces';
+import useKeyDown from 'hooks/useKeyDown';
 import { Back, Container, Details, Forward, Grid, GridLink, Navigation } from './footernav.css';
 
 export interface Props {
@@ -13,6 +15,7 @@ const urlFromPhoto = ({ public_id }: Photo): string => `/albums/${public_id}`;
 
 const FooterNav = ({ album, className, currentPhoto }: Props): JSX.Element => {
   const { photos, name } = album;
+  const router = useRouter();
   const photoCount: number = photos.length;
   const currentIndex: number = photos.findIndex(({ public_id }: Photo) => public_id === currentPhoto.public_id);
   const firstPhoto: Photo = photos[0];
@@ -21,6 +24,19 @@ const FooterNav = ({ album, className, currentPhoto }: Props): JSX.Element => {
   const prevPhoto: Photo | undefined = photos[currentIndex - 1];
   const backUrl: string = urlFromPhoto(prevPhoto ?? lastPhoto);
   const forwardUrl: string = urlFromPhoto(nextPhoto ?? firstPhoto);
+
+  useKeyDown(({ keyCode }): void => {
+    switch (keyCode) {
+      case 37: {
+        router.push('/albums/[albumName]/[public_id]', backUrl);
+        break;
+      }
+      case 39: {
+        router.push('/albums/[albumName]/[public_id]', forwardUrl);
+        break;
+      }
+    }
+  });
 
   return (
     <Container className={className}>

--- a/src/components/header/header.spec.tsx
+++ b/src/components/header/header.spec.tsx
@@ -1,4 +1,4 @@
-jest.mock('next/router', () => ({
+jest.mock('next/router', (): { useRouter: jest.Mock } => ({
   useRouter: jest.fn(),
 }));
 
@@ -12,6 +12,7 @@ describe('Header tests', (): void => {
   const defaultProps: Props = {
     navRevealed: false,
     onMenuButtonClick: jest.fn(),
+    onTitleClick: jest.fn(),
   };
 
   beforeEach(() => {
@@ -22,7 +23,7 @@ describe('Header tests', (): void => {
     }));
   });
 
-  beforeEach((): void => {
+  afterEach((): void => {
     jest.clearAllMocks();
   });
 

--- a/src/hooks/useKeyDown.ts
+++ b/src/hooks/useKeyDown.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+const useKeyDown = (cb: (e: KeyboardEvent) => void): void => {
+  useEffect((): (() => void) => {
+    window.addEventListener('keydown', cb);
+
+    return (): void => window.removeEventListener('keydown', cb);
+  }, [cb]);
+};
+
+export default useKeyDown;

--- a/src/pages/albums/[albumName]/[public_id].tsx
+++ b/src/pages/albums/[albumName]/[public_id].tsx
@@ -10,14 +10,16 @@ interface Props {
   photo: Photo;
 }
 
-const PictureDetail = ({ album, photo }: Props): JSX.Element => (
-  <Layout titlePhoto={photo}>
-    <Container>
-      <PictureSt isDetail lazyLoad photo={photo} />
-    </Container>
-    <FooterNavigation album={album} currentPhoto={photo} />
-  </Layout>
-);
+const PictureDetail = ({ album, photo }: Props): JSX.Element => {
+  return (
+    <Layout titlePhoto={photo}>
+      <Container>
+        <PictureSt isDetail lazyLoad photo={photo} />
+      </Container>
+      <FooterNavigation album={album} currentPhoto={photo} />
+    </Layout>
+  );
+};
 
 export async function getStaticPaths(): Promise<StaticPaths> {
   const paths = await getPhotoPublicIds();


### PR DESCRIPTION
## What is this?
This PR adds keyboard navigation to the photo detail views, so that the user can flick between photos with the left and right arrow keys.

A custom hook has been created for this, which loads the previous or next photo depending on the key code.