### PR TITLE
feat: add generated sitemap

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,9 +4,19 @@ const withMDX = require('@next/mdx')({
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx']
 });
 
+const rewrites = async () => {
+  return [
+    {
+      source: '/sitemap.xml',
+      destination: '/api/sitemap',
+    }
+  ];
+};
+
 module.exports = {
   ...withMDX,
+  rewrites,
   env: {
     version: process.env.npm_package_version
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cinematt",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Personal photography website rebuilt using NextJS",
   "main": "index.js",
   "scripts": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Allow: /
+Disallow: /api
+Sitemap: https://cinematt.photography/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,1545 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+              http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/hohenschenhausen-cell</loc>
+    <lastmod>2017-06-09T09:21:59Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/haus-der-statistiche-2</loc>
+    <lastmod>2017-06-09T09:21:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/rian-ro-kerry-windows</loc>
+    <lastmod>2017-06-09T09:21:55Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/rian-ro-kerry-lobby</loc>
+    <lastmod>2017-06-09T09:21:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/haus-der-statistiche</loc>
+    <lastmod>2017-06-09T09:21:49Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/rian-ro-kerry-bar</loc>
+    <lastmod>2017-06-09T09:21:48Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/cite-foche-reflections</loc>
+    <lastmod>2017-06-09T09:21:43Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/cite-foche-exterior</loc>
+    <lastmod>2017-06-09T09:21:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/cite-foche-hole-wall</loc>
+    <lastmod>2017-06-09T09:21:21Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/cite-foche-cinema</loc>
+    <lastmod>2017-06-09T09:21:17Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/stadtbad-wedding-stairs</loc>
+    <lastmod>2017-06-09T09:21:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/the-glen-shop</loc>
+    <lastmod>2017-06-09T09:21:15Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/cite-foche-offices</loc>
+    <lastmod>2017-06-09T09:21:08Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/rian-ro-kerry</loc>
+    <lastmod>2017-06-09T09:20:59Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/ballinskelligs-cottage</loc>
+    <lastmod>2017-06-09T09:20:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/stadtbad-wedding-blinds</loc>
+    <lastmod>2017-06-09T09:20:37Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/abandoned/stadtbad-wedding-door</loc>
+    <lastmod>2017-06-09T09:20:35Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/rebecca</loc>
+    <lastmod>2020-08-28T17:37:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/kitchner-musician</loc>
+    <lastmod>2020-08-20T21:25:56Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/ian</loc>
+    <lastmod>2020-08-20T20:11:13Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/selfie</loc>
+    <lastmod>2020-08-11T20:14:18Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/leah-megan</loc>
+    <lastmod>2018-10-28T12:16:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/leah-megan-jan</loc>
+    <lastmod>2018-10-28T12:14:56Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/photoshoot-leah</loc>
+    <lastmod>2018-10-16T19:00:19Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/ruairi-li-museum</loc>
+    <lastmod>2018-03-13T20:33:28Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/berlin-birthday-party</loc>
+    <lastmod>2018-03-13T20:33:24Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/li-kindl-stuben</loc>
+    <lastmod>2018-03-13T20:17:43Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/jannowitzbrucke</loc>
+    <lastmod>2018-03-13T20:12:24Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dans_house</loc>
+    <lastmod>2018-03-11T17:17:49Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/paul-chloe</loc>
+    <lastmod>2018-03-11T16:58:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/me-montpelier</loc>
+    <lastmod>2018-03-11T15:53:09Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/nate</loc>
+    <lastmod>2018-03-11T14:57:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/beach-party-arainn-mhor</loc>
+    <lastmod>2018-03-11T14:48:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/run-sign</loc>
+    <lastmod>2018-03-05T19:10:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/stockholm-toymaker</loc>
+    <lastmod>2018-03-04T15:37:14Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/me</loc>
+    <lastmod>2017-06-15T19:39:45Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/yves</loc>
+    <lastmod>2017-06-09T10:53:28Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/vantastival-ross</loc>
+    <lastmod>2017-06-09T10:53:27Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/xha-xhu-zhi</loc>
+    <lastmod>2017-06-09T10:53:24Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/vantastival-vin</loc>
+    <lastmod>2017-06-09T10:53:21Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/viking-renactor</loc>
+    <lastmod>2017-06-09T10:53:17Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/vantastival-rochelle</loc>
+    <lastmod>2017-06-09T10:53:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/unicorns</loc>
+    <lastmod>2017-06-09T10:53:05Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/tree-howth</loc>
+    <lastmod>2017-06-09T10:52:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/street-performer</loc>
+    <lastmod>2017-06-09T10:52:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/phoenix-park-training</loc>
+    <lastmod>2017-06-09T10:52:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/photographer</loc>
+    <lastmod>2017-06-09T10:52:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/spwc-performer</loc>
+    <lastmod>2017-06-09T10:52:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/singer</loc>
+    <lastmod>2017-06-09T10:52:31Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/ruairi-fionn</loc>
+    <lastmod>2017-06-09T10:52:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/portugal-guitarist</loc>
+    <lastmod>2017-06-09T10:52:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/pppb</loc>
+    <lastmod>2017-06-09T10:52:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/peter-coonan-redline</loc>
+    <lastmod>2017-06-09T10:52:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/phil-bans-donegal</loc>
+    <lastmod>2017-06-09T10:52:01Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/paul-james-beach</loc>
+    <lastmod>2017-06-09T10:51:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/paul-and-luke</loc>
+    <lastmod>2017-06-09T10:51:51Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/model-airplane</loc>
+    <lastmod>2017-06-09T10:51:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/li-behind-paper</loc>
+    <lastmod>2017-06-09T10:51:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/li</loc>
+    <lastmod>2017-06-09T10:51:41Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/norwegian-actress-profile</loc>
+    <lastmod>2017-06-09T10:51:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/kluner-kranich-visitors</loc>
+    <lastmod>2017-06-09T10:51:35Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/norwegian-actress-forest-shoot</loc>
+    <lastmod>2017-06-09T10:51:33Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/mossy-laura</loc>
+    <lastmod>2017-06-09T10:51:28Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/lunchtime</loc>
+    <lastmod>2017-06-09T10:51:17Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/mick-beach</loc>
+    <lastmod>2017-06-09T10:51:15Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/knonigs-wusterhausen-ruairi-fionn</loc>
+    <lastmod>2017-06-09T10:51:14Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/li-tempelhof</loc>
+    <lastmod>2017-06-09T10:51:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/lakeside-konigs-wusterhausen</loc>
+    <lastmod>2017-06-09T10:51:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/karneval-der-kulturen-group</loc>
+    <lastmod>2017-06-09T10:50:58Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/jonathan-mum</loc>
+    <lastmod>2017-06-09T10:50:51Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/grogans-finger-chomp</loc>
+    <lastmod>2017-06-09T10:50:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/karneval-der-kulturen</loc>
+    <lastmod>2017-06-09T10:50:49Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/jonathan</loc>
+    <lastmod>2017-06-09T10:50:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/jumper</loc>
+    <lastmod>2017-06-09T10:50:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/jonathan-cliffs</loc>
+    <lastmod>2017-06-09T10:50:30Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/francis-wine-glass</loc>
+    <lastmod>2017-06-09T10:50:27Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/finucane-family</loc>
+    <lastmod>2017-06-09T10:50:27Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dan_and_luke_kitchen</loc>
+    <lastmod>2017-06-09T10:50:20Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dschung-nori</loc>
+    <lastmod>2017-06-09T10:50:20Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/german-actress-forest</loc>
+    <lastmod>2017-06-09T10:50:12Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/david-oliveira</loc>
+    <lastmod>2017-06-09T10:50:11Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/christina-light-museum</loc>
+    <lastmod>2017-06-09T10:50:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/eavan</loc>
+    <lastmod>2017-06-09T10:50:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dschung-standing</loc>
+    <lastmod>2017-06-09T10:50:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dan_sophie</loc>
+    <lastmod>2017-06-09T10:49:51Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/crew-camera-checking</loc>
+    <lastmod>2017-06-09T10:49:48Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dad-lauren</loc>
+    <lastmod>2017-06-09T10:49:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/dschung-hand</loc>
+    <lastmod>2017-06-09T10:49:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/chloe</loc>
+    <lastmod>2017-06-09T10:49:32Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/canal</loc>
+    <lastmod>2017-06-09T10:49:29Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/christina-berlin</loc>
+    <lastmod>2017-06-09T10:49:23Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/christina-matt-berlin</loc>
+    <lastmod>2017-06-09T10:49:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/alberto-david-unicorns</loc>
+    <lastmod>2017-06-09T10:48:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/alberto-dschung</loc>
+    <lastmod>2017-06-09T10:48:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/people/alberto-blindfolded</loc>
+    <lastmod>2017-06-09T10:48:20Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/double-bass</loc>
+    <lastmod>2020-08-28T17:40:44Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/whelans</loc>
+    <lastmod>2017-06-09T10:42:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/prairie-dawgs-ruairi</loc>
+    <lastmod>2017-06-09T10:42:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/violinist</loc>
+    <lastmod>2017-06-09T10:41:56Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/tim-hot-sprockets</loc>
+    <lastmod>2017-06-09T10:41:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/prairie-dawgs-karen</loc>
+    <lastmod>2017-06-09T10:41:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/vantastival-performer</loc>
+    <lastmod>2017-06-09T10:41:48Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/vantastival-singer</loc>
+    <lastmod>2017-06-09T10:41:49Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/the-young-folk-lead</loc>
+    <lastmod>2017-06-09T10:41:45Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/vantastival-guitarist</loc>
+    <lastmod>2017-06-09T10:41:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/tim-hot-sprockets-under-mic</loc>
+    <lastmod>2017-06-09T10:41:32Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/prairie-dawgs-connor</loc>
+    <lastmod>2017-06-09T10:41:18Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/stina</loc>
+    <lastmod>2017-06-09T10:41:18Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/hot-sprockets-leads</loc>
+    <lastmod>2017-06-09T10:41:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/rhob-cunningham</loc>
+    <lastmod>2017-06-09T10:41:14Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/mossy-nolan</loc>
+    <lastmod>2017-06-09T10:41:07Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/alabama-3-guitarist</loc>
+    <lastmod>2017-06-09T10:41:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/richie-cmc</loc>
+    <lastmod>2017-06-09T10:41:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/mixing-desk</loc>
+    <lastmod>2017-06-09T10:40:54Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/hot-sprockets-stage-vantastival</loc>
+    <lastmod>2017-06-09T10:40:48Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/alabama-3-single</loc>
+    <lastmod>2017-06-09T10:40:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/alabama-3-stage</loc>
+    <lastmod>2017-06-09T10:40:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/alabama-3-vocals</loc>
+    <lastmod>2017-06-09T10:40:27Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/colm</loc>
+    <lastmod>2017-06-09T10:40:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/music/alabama-3-lead</loc>
+    <lastmod>2017-06-09T10:40:09Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/bust</loc>
+    <lastmod>2020-08-11T21:07:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/flat-life-gallery</loc>
+    <lastmod>2018-10-28T17:43:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/jablonski-salon</loc>
+    <lastmod>2018-10-28T14:09:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/glendalough-tree</loc>
+    <lastmod>2018-10-25T04:34:45Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/squat-market</loc>
+    <lastmod>2018-10-16T19:04:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/szczecin</loc>
+    <lastmod>2018-03-11T10:46:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/butelka</loc>
+    <lastmod>2018-03-11T10:25:05Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/lovelocks</loc>
+    <lastmod>2018-03-11T09:56:14Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/stockholm</loc>
+    <lastmod>2018-03-11T09:51:14Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/polfors-stockholm</loc>
+    <lastmod>2018-03-11T09:44:00Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/vattern-granna</loc>
+    <lastmod>2018-03-11T09:36:59Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/fika</loc>
+    <lastmod>2018-03-11T09:22:15Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/minature-path</loc>
+    <lastmod>2018-03-11T09:09:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/shooting-gallery</loc>
+    <lastmod>2018-03-05T22:10:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/museum-louisiana</loc>
+    <lastmod>2018-03-05T21:46:05Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/abandoned-hut</loc>
+    <lastmod>2018-03-05T19:54:00Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/tvs</loc>
+    <lastmod>2018-03-05T19:22:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/spiral</loc>
+    <lastmod>2018-03-04T15:32:55Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/orb</loc>
+    <lastmod>2017-06-09T10:37:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/kunst-museum</loc>
+    <lastmod>2017-06-09T10:36:11Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/konigs-wusterhausen</loc>
+    <lastmod>2017-06-09T10:36:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/karl-marx-allee</loc>
+    <lastmod>2017-06-09T10:36:07Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/kitesurfer-tempelhof</loc>
+    <lastmod>2017-06-09T10:36:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/klunkerkranich</loc>
+    <lastmod>2017-06-09T10:36:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/dublin</loc>
+    <lastmod>2017-06-09T10:35:55Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/fence</loc>
+    <lastmod>2017-06-09T10:35:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/fence-poland</loc>
+    <lastmod>2017-06-09T10:35:36Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/tree</loc>
+    <lastmod>2017-06-09T10:35:28Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/easter-prost</loc>
+    <lastmod>2017-06-09T10:35:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/wittenberg</loc>
+    <lastmod>2017-06-09T10:35:20Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/eternit</loc>
+    <lastmod>2017-06-09T10:35:18Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/treptower-war-memorial</loc>
+    <lastmod>2017-06-09T10:35:12Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/deer-park-window</loc>
+    <lastmod>2017-06-09T10:35:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/cliffs-2005</loc>
+    <lastmod>2017-06-09T10:35:01Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/cliffs-2005-cans</loc>
+    <lastmod>2017-06-09T10:34:51Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/channel-tunnel</loc>
+    <lastmod>2017-06-09T10:34:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/charlottenburg-tree</loc>
+    <lastmod>2017-06-09T10:34:49Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/channel-tunnel-self-portrait</loc>
+    <lastmod>2017-06-09T10:34:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/spreepark-ferris-wheel</loc>
+    <lastmod>2017-06-09T10:34:37Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/tempelhof-floodlight</loc>
+    <lastmod>2017-06-09T10:34:34Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/braurei</loc>
+    <lastmod>2017-06-09T10:34:28Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/stadtbadd-wedding</loc>
+    <lastmod>2017-06-09T10:34:15Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/side-street-berlin</loc>
+    <lastmod>2017-06-09T10:34:12Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/side_steps_wall</loc>
+    <lastmod>2017-06-09T10:34:00Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/building-pattern</loc>
+    <lastmod>2017-06-09T10:33:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/schnitzel_konig</loc>
+    <lastmod>2017-06-09T10:33:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/adac-building</loc>
+    <lastmod>2017-06-09T10:33:25Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/mossy-drums</loc>
+    <lastmod>2017-06-09T10:33:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/experimental/scaffold-tunnel</loc>
+    <lastmod>2017-06-09T10:33:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/poulette</loc>
+    <lastmod>2020-08-11T21:18:43Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/haus-schwarzenberg</loc>
+    <lastmod>2018-03-13T20:05:52Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/rosenthaler-str</loc>
+    <lastmod>2018-03-13T20:01:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/city-hall-copenhagen</loc>
+    <lastmod>2018-03-11T08:51:48Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/copenhagen-library</loc>
+    <lastmod>2018-03-04T15:26:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/volkswagen-berlin</loc>
+    <lastmod>2017-06-09T09:27:55Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/west-berlin-apartment-door</loc>
+    <lastmod>2017-06-09T09:27:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/workplace</loc>
+    <lastmod>2017-06-09T09:27:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/window-pattern</loc>
+    <lastmod>2017-06-09T09:27:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/treehouse-klunkerkranich</loc>
+    <lastmod>2017-06-09T09:27:41Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/ubahn-berlin</loc>
+    <lastmod>2017-06-09T09:27:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/look-beautiful-tempelhof</loc>
+    <lastmod>2017-06-09T09:27:36Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/stoplerstein</loc>
+    <lastmod>2017-06-09T09:27:36Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/tara-street-dart</loc>
+    <lastmod>2017-06-09T09:27:32Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/table-tennis-berlin</loc>
+    <lastmod>2017-06-09T09:27:26Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/tempelhof-cyclist</loc>
+    <lastmod>2017-06-09T09:27:21Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/steps</loc>
+    <lastmod>2017-06-09T09:26:56Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/rixdorf-christmas-market</loc>
+    <lastmod>2017-06-09T09:26:54Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/spree-statue</loc>
+    <lastmod>2017-06-09T09:26:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/shopping-trolley</loc>
+    <lastmod>2017-06-09T09:26:52Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/presse-tabak-berlin</loc>
+    <lastmod>2017-06-09T09:26:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/redline-film-take-dublin</loc>
+    <lastmod>2017-06-09T09:26:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/kino-international-berlin</loc>
+    <lastmod>2017-06-09T09:26:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/russian-embassy-berlin</loc>
+    <lastmod>2017-06-09T09:26:33Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/barcelona-ship</loc>
+    <lastmod>2017-06-09T09:26:31Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/portugal-street</loc>
+    <lastmod>2017-06-09T09:26:20Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/poland-house</loc>
+    <lastmod>2017-06-09T09:26:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/phoenix-park-model-plane</loc>
+    <lastmod>2017-06-09T09:26:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/motel-avus</loc>
+    <lastmod>2017-06-09T09:26:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/marienfield-church-ceiling</loc>
+    <lastmod>2017-06-09T09:26:00Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/polizei</loc>
+    <lastmod>2017-06-09T09:25:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/kudamm-christmas</loc>
+    <lastmod>2017-06-09T09:25:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/messe-nord-race-terrace</loc>
+    <lastmod>2017-06-09T09:25:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/marienfeld-church</loc>
+    <lastmod>2017-06-09T09:25:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/kudamm-kiosk</loc>
+    <lastmod>2017-06-09T09:25:33Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/grogans-the-castle</loc>
+    <lastmod>2017-06-09T09:25:23Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/klunkerkranich-chairs</loc>
+    <lastmod>2017-06-09T09:25:23Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/karl-mark-allee-shops</loc>
+    <lastmod>2017-06-09T09:25:21Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/klunkerkranich-fernsehturm</loc>
+    <lastmod>2017-06-09T09:25:18Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/ice-lake-charlottenburg</loc>
+    <lastmod>2017-06-09T09:25:07Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/fontane_trevi</loc>
+    <lastmod>2017-06-09T09:25:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/gluwein-christmas-market</loc>
+    <lastmod>2017-06-09T09:25:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/greifswaler_apartments</loc>
+    <lastmod>2017-06-09T09:25:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/greifswalder-tunnel</loc>
+    <lastmod>2017-06-09T09:25:01Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/casino-berlin</loc>
+    <lastmod>2017-06-09T09:24:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/dublin-street</loc>
+    <lastmod>2017-06-09T09:24:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/film-palast</loc>
+    <lastmod>2017-06-09T09:24:37Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/flasche-tempelhof</loc>
+    <lastmod>2017-06-09T09:24:25Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/expo-center-veb-berlin</loc>
+    <lastmod>2017-06-09T09:24:24Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/eagle-tempelhof</loc>
+    <lastmod>2017-06-09T09:24:22Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/fernsehturm</loc>
+    <lastmod>2017-06-09T09:24:11Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/church_interior</loc>
+    <lastmod>2017-06-09T09:24:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/demonstration-crowd-berlin</loc>
+    <lastmod>2017-06-09T09:24:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/charlottenburg-lake-fisheye</loc>
+    <lastmod>2017-06-09T09:24:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/city-lamp-posters</loc>
+    <lastmod>2017-06-09T09:23:48Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/brandenburger-tor</loc>
+    <lastmod>2017-06-09T09:23:41Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/charlottenburg-statue</loc>
+    <lastmod>2017-06-09T09:23:41Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/berlin-protest-banner</loc>
+    <lastmod>2017-06-09T09:23:41Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/busker-street-berlin</loc>
+    <lastmod>2017-06-09T09:23:37Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/berlin-supermarkt</loc>
+    <lastmod>2017-06-09T09:23:34Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/border</loc>
+    <lastmod>2017-06-09T09:23:33Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/berlin-christmas-market-shed</loc>
+    <lastmod>2017-06-09T09:23:14Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/berlin-expo-messe-nord</loc>
+    <lastmod>2017-06-09T09:23:11Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/berlin-demonstration-lying-down</loc>
+    <lastmod>2017-06-09T09:23:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/berlin-christmas-market</loc>
+    <lastmod>2017-06-09T09:23:07Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/bankomat-berlin</loc>
+    <lastmod>2017-06-09T09:22:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/city/alt-neue-berlin</loc>
+    <lastmod>2017-06-09T09:22:54Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/bastei</loc>
+    <lastmod>2020-08-11T20:57:54Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/glendalough-miners-village</loc>
+    <lastmod>2018-10-25T04:31:12Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/glendalough-lake</loc>
+    <lastmod>2018-10-25T04:29:05Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/glendalough-bridge-valley</loc>
+    <lastmod>2018-10-25T04:27:30Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/west-germany</loc>
+    <lastmod>2018-03-11T17:15:18Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/oresund-bridge</loc>
+    <lastmod>2018-03-11T08:40:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/trellerborg-boat</loc>
+    <lastmod>2018-03-11T08:17:30Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/sodertalje-lake</loc>
+    <lastmod>2018-03-04T15:30:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/halmstad-beach</loc>
+    <lastmod>2018-03-04T15:28:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/baltic-sea</loc>
+    <lastmod>2018-03-03T17:13:39Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/kerry-sheep</loc>
+    <lastmod>2017-06-09T10:39:15Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/st-finians-beach</loc>
+    <lastmod>2017-06-09T10:39:10Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/seagull-poland</loc>
+    <lastmod>2017-06-09T10:39:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/skelligs-kerry</loc>
+    <lastmod>2017-06-09T10:39:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/tree-killarney</loc>
+    <lastmod>2017-06-09T10:39:03Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/st-finans-bay-long-exposure</loc>
+    <lastmod>2017-06-09T10:38:58Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/lakes-killarney</loc>
+    <lastmod>2017-06-09T10:38:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/howth-harbour</loc>
+    <lastmod>2017-06-09T10:38:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/lake</loc>
+    <lastmod>2017-06-09T10:38:38Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/glendalough-tower</loc>
+    <lastmod>2017-06-09T10:38:32Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/dublin-from-howth</loc>
+    <lastmod>2017-06-09T10:38:29Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/kerry-cottage-long-exposure</loc>
+    <lastmod>2017-06-09T10:38:20Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/howth-fishing-boat</loc>
+    <lastmod>2017-06-09T10:38:19Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/glendalough-landscape</loc>
+    <lastmod>2017-06-09T10:38:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/howth-harbour-lighthouse</loc>
+    <lastmod>2017-06-09T10:38:17Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/howth_pier</loc>
+    <lastmod>2017-06-09T10:38:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/glendalough-path</loc>
+    <lastmod>2017-06-09T10:37:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/landscapes/forest</loc>
+    <lastmod>2017-06-09T10:37:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/refeshments</loc>
+    <lastmod>2017-06-09T10:04:07Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/spirit-of-folk-shield</loc>
+    <lastmod>2017-06-09T10:04:07Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/spirit-of-folk-musician</loc>
+    <lastmod>2017-06-09T10:04:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/spirit-of-folk-tent</loc>
+    <lastmod>2017-06-09T10:04:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/praater</loc>
+    <lastmod>2017-06-09T10:03:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/spirit-of-folk-people</loc>
+    <lastmod>2017-06-09T10:03:51Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/karneval-der-kulturen-people</loc>
+    <lastmod>2017-06-09T10:03:32Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/northwest-200</loc>
+    <lastmod>2017-06-09T10:03:30Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/karneval-der-kulturen-sandals</loc>
+    <lastmod>2017-06-09T10:03:28Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/karneval-der-kulturen-mojito</loc>
+    <lastmod>2017-06-09T10:03:26Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/meteor-meetup</loc>
+    <lastmod>2017-06-09T10:03:19Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/karneval-der-kulturen-hat</loc>
+    <lastmod>2017-06-09T10:03:09Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/easter-market-cakes</loc>
+    <lastmod>2017-06-09T10:03:04Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/spwc-dublin-waldos</loc>
+    <lastmod>2017-06-09T10:02:57Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/karneval-der-kulturen-dress</loc>
+    <lastmod>2017-06-09T10:02:54Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/weinachts-markt-2016</loc>
+    <lastmod>2017-06-09T10:02:53Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/vantastival-2011-group</loc>
+    <lastmod>2017-06-09T10:02:47Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/vantastival-2011</loc>
+    <lastmod>2017-06-09T10:02:45Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/berlin-5k-ruairi</loc>
+    <lastmod>2017-06-09T10:02:43Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/vantastival-2011-daytime-gs</loc>
+    <lastmod>2017-06-09T10:02:41Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/events/berlin-10k-group</loc>
+    <lastmod>2017-06-09T10:02:34Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/dragonfly</loc>
+    <lastmod>2020-08-20T21:14:08Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/waterplant</loc>
+    <lastmod>2020-08-20T20:18:52Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/grenouille</loc>
+    <lastmod>2020-08-20T20:02:00Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/spirit-of-folk-bird</loc>
+    <lastmod>2017-06-09T10:45:17Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/schneedrop</loc>
+    <lastmod>2017-06-09T10:45:09Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/rupert-clarissa</loc>
+    <lastmod>2017-06-09T10:45:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/plant-labels</loc>
+    <lastmod>2017-06-09T10:45:05Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/phi-phi-monkey</loc>
+    <lastmod>2017-06-09T10:45:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/phoenix-park-deer</loc>
+    <lastmod>2017-06-09T10:45:02Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/leaves-water</loc>
+    <lastmod>2017-06-09T10:44:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/lahu-village-cat</loc>
+    <lastmod>2017-06-09T10:44:42Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/pai-parrot</loc>
+    <lastmod>2017-06-09T10:44:40Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/howth-horse</loc>
+    <lastmod>2017-06-09T10:44:27Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/bird-closeup</loc>
+    <lastmod>2017-06-09T10:44:19Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/frosted-leaves</loc>
+    <lastmod>2017-06-09T10:44:17Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/pai-cat</loc>
+    <lastmod>2017-06-09T10:44:16Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/kerry-road-horse</loc>
+    <lastmod>2017-06-09T10:44:06Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/bird-poised</loc>
+    <lastmod>2017-06-09T10:44:05Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/dark-grass</loc>
+    <lastmod>2017-06-09T10:43:52Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/balcony-plants</loc>
+    <lastmod>2017-06-09T10:43:50Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/cliffs-toadstool</loc>
+    <lastmod>2017-06-09T10:43:49Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/albums/nature/blumen</loc>
+    <lastmod>2017-06-09T10:43:46Z</lastmod>
+  </url>
+
+  <url>
+    <loc>https//cinematt.photography/about</loc>
+    <lastmod>2020-09-09T17:46:00Z</lastmod>
+  </url>
+</urlset>

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,3 +82,5 @@ export const detailSourceMediaQueries: PictureSourceSize[] = [
 ];
 
 export const resourceBaseUrl = 'https://res.cloudinary.com/matt-finucane-portfolio/image/upload';
+
+export const sitemapBaseUrl = 'https//cinematt.photography';

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,15 @@
+import { albums } from 'config';
+import { getAlbum } from 'lib/albums';
+import { Album, Photo, SitemapEntry } from 'models/interfaces';
+
+export const getSitemapRoutes = async (): Promise<SitemapEntry[]> => {
+  const allAlbums: Album[] = await Promise.all(albums.map((name: string): Promise<Album> => getAlbum(name)));
+  const allPhotos: Photo[] = allAlbums.map(({ photos }: Album) => photos).flat();
+
+  return allPhotos.map(
+    ({ album, created_at, name }: Photo): SitemapEntry => ({
+      lastmod: created_at.toString(),
+      loc: `albums/${album}/${name}`,
+    }),
+  );
+};

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -26,6 +26,11 @@ export interface PictureParam {
   };
 }
 
+export interface SitemapEntry {
+  lastmod: string;
+  loc: string;
+}
+
 export interface Color {
   code: string;
   weight: number;
@@ -62,6 +67,12 @@ export interface StaticAlbumProps {
   props: {
     album: Album;
     titlePhoto?: Photo;
+  };
+}
+
+export interface StaticSitemapProps {
+  props: {
+    entries: SitemapEntry[];
   };
 }
 

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -1,0 +1,39 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { sitemapBaseUrl } from 'config';
+import { SitemapEntry } from 'models/interfaces';
+import { getSitemapRoutes } from 'lib/sitemap';
+
+const sitemap = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  const aboutPage: SitemapEntry = {
+    loc: 'about',
+    lastmod: '2020-09-09T17:46:00Z',
+  };
+  const entries: SitemapEntry[] = [...(await getSitemapRoutes()), aboutPage];
+  const sitemap: string = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+              http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      >
+        ${entries
+          .map(
+            ({ lastmod, loc }: SitemapEntry) => `
+          <url>
+            <loc>${sitemapBaseUrl}/${loc}</loc>
+            <lastmod>${lastmod}</lastmod>
+          </url>`,
+          )
+          .join('\n')}
+      </urlset>
+    `.trim();
+
+  res.writeHead(200, {
+    'Content-Type': 'application/xml',
+  });
+
+  return res.end(sitemap);
+};
+
+export default sitemap;


### PR DESCRIPTION
## What is this?
This PR adds a generated sitemap indexing all pages and photos. It leverages the [NextJS API Routes](https://nextjs.org/docs/api-routes/dynamic-api-routes) which are server side only, to generate the sitemap content. 